### PR TITLE
Fix incorrect condition in version check

### DIFF
--- a/src/main/kotlin/dev/zacsweers/kgp/Kgp150LeakPatcherPlugin.kt
+++ b/src/main/kotlin/dev/zacsweers/kgp/Kgp150LeakPatcherPlugin.kt
@@ -14,7 +14,7 @@ class Kgp150LeakPatcherPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     val embeddableVersion = parseCompilerEmbeddedVersionNumber()
 
-    if (isApplicable(embeddableVersion)) {
+    if (!isApplicable(embeddableVersion)) {
       project.logger.warn("KGP 1.5.0 Leak Patcher plugin is only applicable to Kotlin 1.5.0. Detected version '$embeddableVersion'.")
       return
     }


### PR DESCRIPTION
When this was refactored for testing the condition was inverted.

Applying the plugin right now results in this:

`KGP 1.5.0 Leak Patcher plugin is only applicable to Kotlin 1.5.0. Detected version '1.5.0'.`