### PR TITLE
Support Configuration Caching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ apply(plugin = "dev.zacsweers.kgp-150-leak-patcher")
 
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snapshots].
 
-## Caveats
-
-Due to its usage of a `BuildListener`, this plugin is incompatible with [Configuration Caching](https://docs.gradle.org/current/userguide/configuration_cache.html). This is unavoidable (the leak it patches was, itself, part of work to make KGP compatible with Configurationg Caching), so you would need to put potentially enabling that on hold until Kotlin 1.5.10 (ETA ~end of May).
-
 License
 -------
 

--- a/src/main/kotlin/dev/zacsweers/kgp/Kgp150LeakPatcherBuildService.kt
+++ b/src/main/kotlin/dev/zacsweers/kgp/Kgp150LeakPatcherBuildService.kt
@@ -1,0 +1,29 @@
+package dev.zacsweers.kgp
+
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import org.jetbrains.kotlin.cli.common.CompilerSystemProperties
+
+/**
+ * By implementing [AutoCloseable], Gradle will call the [close] method at the end of the build.
+ */
+internal abstract class Kgp150LeakPatcherBuildService : BuildService<BuildServiceParameters.None>, AutoCloseable {
+
+  override fun close() {
+    CompilerSystemProperties.systemPropertyGetter = SystemPropertyGetter()
+    CompilerSystemProperties.systemPropertySetter = SystemPropertySetter()
+    CompilerSystemProperties.systemPropertyCleaner = SystemPropertyCleaner()
+  }
+}
+
+private class SystemPropertyGetter : (String) -> String? {
+  override operator fun invoke(p1: String): String? = System.getProperty(p1)
+}
+
+private class SystemPropertySetter : (String, String) -> String? {
+  override operator fun invoke(o1: String, o2: String): String = System.setProperty(o1, o2)
+}
+
+private class SystemPropertyCleaner : (String) -> String? {
+  override operator fun invoke(p1: String): String = System.clearProperty(p1)
+}

--- a/src/main/kotlin/dev/zacsweers/kgp/Kgp150LeakPatcherPlugin.kt
+++ b/src/main/kotlin/dev/zacsweers/kgp/Kgp150LeakPatcherPlugin.kt
@@ -19,11 +19,9 @@ class Kgp150LeakPatcherPlugin : Plugin<Project> {
       return
     }
 
-    project.gradle.buildFinished {
-      CompilerSystemProperties.systemPropertyGetter = SystemPropertyGetter()
-      CompilerSystemProperties.systemPropertySetter = SystemPropertySetter()
-      CompilerSystemProperties.systemPropertyCleaner = SystemPropertyCleaner()
-    }
+    project.gradle.sharedServices.registerIfAbsent("kgp-150-leak-patcher", Kgp150LeakPatcherBuildService::class.java) {}
+      // Force the BuildService to be loaded into memory immediately.
+      .get()
   }
 }
 
@@ -50,16 +48,4 @@ internal fun parseCompilerEmbeddedVersionNumber(
     ?.let(VersionNumber::parse)
     ?.baseVersion
     ?: VersionNumber.UNKNOWN
-}
-
-private class SystemPropertyGetter : (String) -> String? {
-  override operator fun invoke(p1: String): String? = System.getProperty(p1)
-}
-
-private class SystemPropertySetter : (String, String) -> String? {
-  override operator fun invoke(o1: String, o2: String): String = System.setProperty(o1, o2)
-}
-
-private class SystemPropertyCleaner : (String) -> String? {
-  override operator fun invoke(p1: String): String = System.clearProperty(p1)
 }


### PR DESCRIPTION
In lieu of using a BuildListener, registering a BuildService that implements AutoCloseable will still allow Gradle to notify us of when the build has completed.

[This method is also compatible with Configuration Caching.](https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements:build_listeners)